### PR TITLE
Get defined functions and calculate the version

### DIFF
--- a/coveralls.json
+++ b/coveralls.json
@@ -1,5 +1,8 @@
 {
   "coverage_options": {
     "minimum_coverage": 85
-  }
+  },
+  "skip_files": [
+    "test/support"
+  ]
 }

--- a/lib/scapa/documented_functions_finder.ex
+++ b/lib/scapa/documented_functions_finder.ex
@@ -1,0 +1,32 @@
+defmodule Scapa.DocumentedFunctionsFinder do
+  @moduledoc false
+  alias Scapa.FunctionDefinition
+
+  @type source() :: {:module, module()}
+
+  @doc """
+  Returns a FunctionDefinition for each function present in the source with a
+  @doc tag.
+  """
+  @spec find_in([source()]) :: [FunctionDefinition.t()]
+  def find_in(sources) do
+    Enum.flat_map(sources, fn {:module, module} -> docs_from_module(module) end)
+  end
+
+  defp docs_from_module(module) do
+    {:docs_v1, _, :elixir, _, _, _, docs} = Code.fetch_docs(module)
+
+    docs
+    |> Enum.filter(&has_doc?/1)
+    |> Enum.map(fn
+      {{:function, name, arity}, _, [string_signature], _, metadata} ->
+        %FunctionDefinition{
+          signature: {module, name, arity, string_signature},
+          version: metadata[:version]
+        }
+    end)
+  end
+
+  defp has_doc?({_, _, _, doc_content, _}) when doc_content in [:none, :hidden], do: false
+  defp has_doc?(_), do: true
+end

--- a/lib/scapa/function_definition.ex
+++ b/lib/scapa/function_definition.ex
@@ -4,9 +4,9 @@ defmodule Scapa.FunctionDefinition do
   @type signature() :: {module(), atom(), arity(), String.t()}
 
   @type t :: %__MODULE__{
-    signature: signature(),
-    version: nil | String.t()
-  }
+          signature: signature(),
+          version: nil | String.t()
+        }
 
   defstruct [:signature, :version]
 end

--- a/lib/scapa/function_definition.ex
+++ b/lib/scapa/function_definition.ex
@@ -1,0 +1,12 @@
+defmodule Scapa.FunctionDefinition do
+  @moduledoc false
+
+  @type signature() :: {module(), atom(), arity(), String.t()}
+
+  @type t :: %__MODULE__{
+    signature: signature(),
+    version: nil | String.t()
+  }
+
+  defstruct [:signature, :version]
+end

--- a/lib/scapa/version_calculator.ex
+++ b/lib/scapa/version_calculator.ex
@@ -1,0 +1,19 @@
+defmodule Scapa.VersionCalculator do
+  @moduledoc false
+  alias Scapa.FunctionDefinition
+
+  @type version() :: String.t()
+
+  @doc """
+  Calculates the version of a function definition based on it's signature.
+
+  ## Examples
+
+    iex> Scapa.VersionCalculator.calculate(%Scapa.FunctionDefinition{signature: {Scapa.VersionCalculator, :hello, 1, "hello(arg1)"}})
+    "47674823"
+  """
+  @spec calculate(FunctionDefinition.t()) :: version()
+  def calculate(%FunctionDefinition{signature: signature}) do
+    Integer.to_string(:erlang.phash2(signature))
+  end
+end

--- a/test/scapa/documented_functions_finder_test.exs
+++ b/test/scapa/documented_functions_finder_test.exs
@@ -1,0 +1,89 @@
+defmodule Scapa.DocumentedFunctionsFinderTest do
+  use ExUnit.Case, async: true
+  alias Scapa.DocumentedFunctionsFinder
+  alias Scapa.FunctionDefinition
+
+  describe "find_in/1" do
+    test "returns functions with docs" do
+      assert [
+               %FunctionDefinition{
+                 signature: {Scapa.ModuleWithDoc, :public_with_doc, 0, "public_with_doc()"}
+               }
+             ] =
+               function_docs(
+                 DocumentedFunctionsFinder.find_in([{:module, Scapa.ModuleWithDoc}]),
+                 :public_with_doc
+               )
+    end
+
+    test "adds the version if present" do
+      assert [
+               %FunctionDefinition{
+                 signature:
+                   {Scapa.ModuleWithDoc, :public_with_version, 0, "public_with_version()"},
+                 version: "abc"
+               }
+             ] =
+               function_docs(
+                 DocumentedFunctionsFinder.find_in([{:module, Scapa.ModuleWithDoc}]),
+                 :public_with_version
+               )
+    end
+
+    test "returns the correct doc for functions with multiple definitions" do
+      assert [
+               %FunctionDefinition{
+                 signature: {Scapa.ModuleWithDoc, :multiple_def, 1, "multiple_def(arg1)"}
+               }
+             ] =
+               function_docs(
+                 DocumentedFunctionsFinder.find_in([{:module, Scapa.ModuleWithDoc}]),
+                 :multiple_def
+               )
+    end
+
+    test "returns the correct doc for functions with multiple definitions and default parameters" do
+      assert [
+               %FunctionDefinition{
+                 signature:
+                   {Scapa.ModuleWithDoc, :multiple_def_with_default, 1,
+                    ~S{multiple_def_with_default(num \\ 42)}}
+               }
+             ] =
+               function_docs(
+                 DocumentedFunctionsFinder.find_in([{:module, Scapa.ModuleWithDoc}]),
+                 :multiple_def_with_default
+               )
+    end
+
+    test "returns functions from hidden doc modules" do
+      assert [
+               %FunctionDefinition{
+                 signature: {Scapa.ModuleWithHiddenDoc, :public_with_doc, 0, "public_with_doc()"}
+               }
+             ] =
+               function_docs(
+                 DocumentedFunctionsFinder.find_in([{:module, Scapa.ModuleWithHiddenDoc}]),
+                 :public_with_doc
+               )
+    end
+
+    test "does not include functions without doc" do
+      docs = DocumentedFunctionsFinder.find_in([{:module, Scapa.ModuleWithDoc}])
+
+      assert [] = function_docs(docs, :public_no_doc)
+    end
+
+    test "does not include private functions" do
+      docs = DocumentedFunctionsFinder.find_in([{:module, Scapa.ModuleWithDoc}])
+
+      assert [] = function_docs(docs, :private_fun)
+    end
+  end
+
+  defp function_docs(docs, function_name) do
+    Enum.filter(docs, fn %FunctionDefinition{signature: {_, name, _, _}} ->
+      name == function_name
+    end)
+  end
+end

--- a/test/scapa/version_calculator_test.exs
+++ b/test/scapa/version_calculator_test.exs
@@ -1,0 +1,23 @@
+defmodule Scapa.VersionCalculatorTest do
+  use ExUnit.Case, async: true
+  doctest Scapa.VersionCalculator
+
+  alias Scapa.VersionCalculator
+  alias Scapa.FunctionDefinition
+
+  describe "calculate/1" do
+    test "returns the same version for the same function signature" do
+      signature_a = {__MODULE__, :hello, 2, "hello(arg1, arg2)"}
+      signature_b = {__MODULE__, :hello, 2, "hello(arg1, arg2)"}
+
+      assert VersionCalculator.calculate(%FunctionDefinition{signature: signature_a}) == VersionCalculator.calculate(%FunctionDefinition{signature: signature_b})
+    end
+
+    test "returns a different version when the function signature changes" do
+      signature_a = {__MODULE__, :hello, 1, "hello(arg1)"}
+      signature_b = {__MODULE__, :hello, 2, "hello(arg1, arg2)"}
+
+      assert VersionCalculator.calculate(%FunctionDefinition{signature: signature_a}) != VersionCalculator.calculate(%FunctionDefinition{signature: signature_b})
+    end
+  end
+end

--- a/test/scapa/version_calculator_test.exs
+++ b/test/scapa/version_calculator_test.exs
@@ -10,14 +10,16 @@ defmodule Scapa.VersionCalculatorTest do
       signature_a = {__MODULE__, :hello, 2, "hello(arg1, arg2)"}
       signature_b = {__MODULE__, :hello, 2, "hello(arg1, arg2)"}
 
-      assert VersionCalculator.calculate(%FunctionDefinition{signature: signature_a}) == VersionCalculator.calculate(%FunctionDefinition{signature: signature_b})
+      assert VersionCalculator.calculate(%FunctionDefinition{signature: signature_a}) ==
+               VersionCalculator.calculate(%FunctionDefinition{signature: signature_b})
     end
 
     test "returns a different version when the function signature changes" do
       signature_a = {__MODULE__, :hello, 1, "hello(arg1)"}
       signature_b = {__MODULE__, :hello, 2, "hello(arg1, arg2)"}
 
-      assert VersionCalculator.calculate(%FunctionDefinition{signature: signature_a}) != VersionCalculator.calculate(%FunctionDefinition{signature: signature_b})
+      assert VersionCalculator.calculate(%FunctionDefinition{signature: signature_a}) !=
+               VersionCalculator.calculate(%FunctionDefinition{signature: signature_b})
     end
   end
 end

--- a/test/scapa/version_calculator_test.exs
+++ b/test/scapa/version_calculator_test.exs
@@ -2,8 +2,8 @@ defmodule Scapa.VersionCalculatorTest do
   use ExUnit.Case, async: true
   doctest Scapa.VersionCalculator
 
-  alias Scapa.VersionCalculator
   alias Scapa.FunctionDefinition
+  alias Scapa.VersionCalculator
 
   describe "calculate/1" do
     test "returns the same version for the same function signature" do

--- a/test/support/module_with_doc.ex
+++ b/test/support/module_with_doc.ex
@@ -1,0 +1,27 @@
+defmodule Scapa.ModuleWithDoc do
+  @moduledoc """
+  Test module used to test the returned function definitions and
+  the corresponding version.
+  """
+
+  @doc "Public with doc"
+  def public_with_doc, do: nil
+
+  @doc "Public with version"
+  @doc version: "abc"
+  def public_with_version, do: nil
+
+  @doc "Multiple def"
+  def multiple_def(1), do: 2
+  def multiple_def("2"), do: 4
+
+  @doc "Multiple def with default"
+  def multiple_def_with_default(num \\ 42)
+
+  def multiple_def_with_default(1), do: 2
+  def multiple_def_with_default(2), do: 4
+
+  def public_no_doc, do: nil
+
+  defp private_fun, do: nil
+end

--- a/test/support/module_with_hidden_doc.ex
+++ b/test/support/module_with_hidden_doc.ex
@@ -1,0 +1,6 @@
+defmodule Scapa.ModuleWithHiddenDoc do
+  @moduledoc false
+
+  @doc "Public with doc"
+  def public_with_doc, do: nil
+end


### PR DESCRIPTION
Uses `Code.fetch_docs/1` to get functions with defined doc tags and `:erlang.phash2/1` to get the versions of those definitions.