### PR TITLE
Allow using config files

### DIFF
--- a/.scapa.exs
+++ b/.scapa.exs
@@ -1,0 +1,3 @@
+[
+  include: "lib/**/*.ex"
+]

--- a/lib/mix/tasks/scapa.gen.versions.ex
+++ b/lib/mix/tasks/scapa.gen.versions.ex
@@ -1,11 +1,13 @@
 defmodule Mix.Tasks.Scapa.Gen.Versions do
   @moduledoc false
 
-  @default_file_pattern "lib/**/*.ex"
+  alias Scapa.Config
 
   @doc false
   def run(_argv) do
-    for {path, content} <- Scapa.CLI.generate_versions(@default_file_pattern),
+    config = Config.fetch_config()
+
+    for {path, content} <- Scapa.CLI.generate_versions(config),
         do: File.write(path, content)
   end
 end

--- a/lib/scapa/cli.ex
+++ b/lib/scapa/cli.ex
@@ -1,22 +1,23 @@
 defmodule Scapa.CLI do
   @moduledoc false
 
+  alias Scapa.Config
   alias Scapa.FunctionDefinition
   alias Scapa.VersionCalculator
 
   @doc """
   Receives a pattern for files to look into and generates versions for those
   """
-  @doc version: "124861924"
-  def generate_versions(files_pattern) do
-    files_to_versionate(files_pattern)
+  @doc version: "34012995"
+  def generate_versions(%Config{include: files_patterns}) do
+    files_to_versionate(files_patterns)
     |> Enum.map(&{&1, add_versions_to_file(&1)})
     |> Enum.filter(&elem(&1, 1))
   end
 
-  defp files_to_versionate(files_pattern) do
-    files_pattern
-    |> Path.wildcard()
+  defp files_to_versionate(files_patterns) do
+    files_patterns
+    |> Enum.flat_map(&Path.wildcard/1)
     |> Enum.map(&Path.expand/1)
     |> MapSet.new()
   end

--- a/lib/scapa/config.ex
+++ b/lib/scapa/config.ex
@@ -1,0 +1,52 @@
+defmodule Scapa.Config do
+  @moduledoc false
+
+  @type path :: String.t()
+  @type t :: %__MODULE__{
+          include: [path]
+        }
+
+  defstruct [:include]
+
+  @config_path ".scapa.exs"
+  @default_config [
+    include: "lib/**/*.ex"
+  ]
+
+  @doc """
+  Returns the config for the project if present and fills missing values from the
+  default config. The default path for the config file is ".scapa.exs" and all
+  options defined there should all be present in the Config struct.
+  """
+  @spec fetch_config(path) :: t()
+  @doc version: "69040384"
+  def fetch_config(path \\ @config_path) do
+    @default_config
+    |> merge_project_config(path)
+    |> format_config()
+    |> then(&struct!(__MODULE__, &1))
+  end
+
+  defp merge_project_config(config, path) do
+    Keyword.merge(config, read_project_config(path))
+  end
+
+  defp read_project_config(path) do
+    if File.exists?(path) do
+      {opts, _} = Code.eval_file(path)
+
+      unless Keyword.keyword?(opts) do
+        raise ArgumentError,
+              "Expected #{inspect(path)} to return a keyword list, got: #{inspect(opts)}"
+      end
+
+      opts
+    else
+      Keyword.new()
+    end
+  end
+
+  defp format_config(config) do
+    Keyword.update!(config, :include, &List.wrap/1)
+  end
+end

--- a/test/scapa/cli_test.exs
+++ b/test/scapa/cli_test.exs
@@ -2,10 +2,13 @@ defmodule Scapa.CLITest do
   use ExUnit.Case, async: true
 
   alias Scapa.CLI
+  alias Scapa.Config
+
+  @config %Config{include: ["test/support/*.ex"]}
 
   describe "generate_versions/1" do
     test "returns the file location and new source code wih versions" do
-      [module_with_doc, module_with_hidden_doc] = CLI.generate_versions("test/support/*.ex")
+      [module_with_doc, module_with_hidden_doc] = CLI.generate_versions(@config)
 
       assert String.ends_with?(elem(module_with_doc, 0), "/support/module_with_doc.ex")
 

--- a/test/scapa/config_test.exs
+++ b/test/scapa/config_test.exs
@@ -1,0 +1,32 @@
+defmodule Scapa.ConfigTest do
+  use ExUnit.Case, async: true
+
+  alias Scapa.Config
+
+  describe "fetch_config/1" do
+    test "reads config from a given path" do
+      assert %Config{include: ["all/my/files/*.exs"]} =
+               Config.fetch_config("test/support/config_files/.scapa.exs")
+    end
+
+    test "injects default when the file does not exist" do
+      assert %Config{include: ["lib/**/*.ex"]} = Config.fetch_config("does/not-exists/.scapa.exs")
+    end
+
+    test "raises an error with extra arguments" do
+      assert_raise KeyError,
+                   ~s(key :invalid not found in: %Scapa.Config{include: ["all/my/files/*.exs"]}),
+                   fn ->
+                     Config.fetch_config("test/support/config_files/.scapa_extra_configs.exs")
+                   end
+    end
+
+    test "raises an error with non-keyword configs" do
+      assert_raise ArgumentError,
+                   ~s(Expected "test/support/config_files/.scapa_not_keyword.exs" to return a keyword list, got: %{include: "soy/el/mapa/*.ex"}),
+                   fn ->
+                     Config.fetch_config("test/support/config_files/.scapa_not_keyword.exs")
+                   end
+    end
+  end
+end

--- a/test/support/config_files/.scapa.exs
+++ b/test/support/config_files/.scapa.exs
@@ -1,0 +1,3 @@
+[
+  include: "all/my/files/*.exs"
+]

--- a/test/support/config_files/.scapa_extra_configs.exs
+++ b/test/support/config_files/.scapa_extra_configs.exs
@@ -1,0 +1,4 @@
+[
+  include: "all/my/files/*.exs",
+  invalid: "This is not supported"
+]

--- a/test/support/config_files/.scapa_not_keyword.exs
+++ b/test/support/config_files/.scapa_not_keyword.exs
@@ -1,0 +1,3 @@
+%{
+  include: "soy/el/mapa/*.ex"
+}


### PR DESCRIPTION
Gets basic configs from `.scapa.exs`